### PR TITLE
updated torch.load params

### DIFF
--- a/model_coverage.py
+++ b/model_coverage.py
@@ -91,7 +91,7 @@ class KeywordCoverage():
         return masked
 
     def reload_model(self, model_file):
-        print(self.model.load_state_dict(torch.load(model_file), strict=False))
+        print(self.model.load_state_dict(torch.load(model_file, map_location=torch.device(self.device)), strict=False))
 
     def save_model(self, model_file):
         torch.save(self.model.state_dict(), model_file)

--- a/model_generator.py
+++ b/model_generator.py
@@ -36,7 +36,7 @@ class GeneTransformer:
         self.mode = "train"
 
     def reload(self, from_file):
-        print(self.model.load_state_dict(torch.load(from_file), strict=False))
+        print(self.model.load_state_dict(torch.load(from_file, map_location=torch.device(self.device)), strict=False))
 
     def save(self, to_file):
         torch.save(self.model.state_dict(), to_file)


### PR DESCRIPTION
Updated occurrences of torch.load to include map_location parameter.  When attempting to train with --device set to cpu, torch.load may attempt to load a file with GPU tensors, which will lead to loading to GPU by default (see: [https://pytorch.org/docs/stable/generated/torch.load.html]()).  If --device is set to cpu, this will error on a cpu-only machine.  Otherwise, it will go against desired functionality. This pull request resolves this issue.